### PR TITLE
configurable retry delay in DJRetryException

### DIFF
--- a/DJJob.php
+++ b/DJJob.php
@@ -4,7 +4,17 @@
 
 class DJException extends Exception { }
 
-class DJRetryException extends DJException { }
+class DJRetryException extends DJException {
+
+    private $delay_seconds = 7200;
+
+    public function setDelay($delay) {
+        $this->delay_seconds = $delay;
+    }
+    public function getDelay() {
+        return $this->delay_seconds;
+    }
+}
 
 class DJBase {
 
@@ -248,9 +258,18 @@ class DJJob extends DJBase {
             return true;
 
         } catch (DJRetryException $e) {
+            # attempts hasn't been incremented yet.
+            $attempts = $this->getAttempts()+1;
 
-            # signal that this job should be retried later
-            $this->retryLater();
+            $msg = "Caught DJRetryException \"{$e->getMessage()}\" on attempt $attempts/{$this->max_attempts}.";
+
+            if($attempts == $this->max_attempts) {
+                $this->log("[JOB] job::{$this->job_id} $msg Giving up.");
+                $this->finishWithError($msg);
+            } else {
+                $this->log("[JOB] job::{$this->job_id} $msg Try again in {$e->getDelay()} seconds.", self::WARN);
+                $this->retryLater($e->getDelay());
+            }
             return false;
 
         } catch (Exception $e) {
@@ -313,13 +332,16 @@ class DJJob extends DJBase {
         $this->releaseLock();
     }
 
-    public function retryLater() {
+    public function retryLater($delay) {
         $this->runUpdate("
             UPDATE jobs
-            SET run_at = DATE_ADD(NOW(), INTERVAL 2 HOUR),
+            SET run_at = DATE_ADD(NOW(), INTERVAL ? SECOND),
                 attempts = attempts + 1
             WHERE id = ?",
-            array($this->job_id)
+            array(
+              $delay,
+              $this->job_id
+            )
         );
         $this->releaseLock();
     }
@@ -330,6 +352,15 @@ class DJJob extends DJBase {
             array($this->job_id)
         );
         foreach ($rs as $r) return unserialize($r["handler"]);
+        return false;
+    }
+
+    public function getAttempts() {
+        $rs = $this->runQuery(
+            "SELECT attempts FROM jobs WHERE id = ?",
+            array($this->job_id)
+        );
+        foreach ($rs as $r) return $r["attempts"];
         return false;
     }
 


### PR DESCRIPTION
Patch allows code like:  `throw new DJJobException('Exception message.', 5);`, meaning try the job again in 5 seconds.  2nd argument is optional.  If omitted, the default is the same as current DJJob behavior (2 hour delay).

In current DJJob, jobs can be scheduled for retry even if that retry would exceed `max_attempts`.  A job like this will sit in the queue forever since the selection logic will see it's been tried too many times, but the job won't be failed.  This patch also resolves that issue by failing a job which has hit its `max_attempts` value through retries.

Worker log output looks like:

```
2011-12-21 15:15:43 [JOB] Starting worker host::dev.ted.com pid::18181 on queue::default
2011-12-21 15:15:43 [JOB] attempting to acquire lock for job::12 on host::dev.ted.com pid::18181
2011-12-21 15:15:43 [JOB] job::12 Caught DJRetryException 'Exception message.' on attempt 1/3. Try again in 5 seconds.
2011-12-21 15:15:48 [JOB] attempting to acquire lock for job::12 on host::dev.ted.com pid::18181
2011-12-21 15:15:48 [JOB] job::12 Caught DJRetryException 'Exception message.' on attempt 2/3. Try again in 5 seconds.
2011-12-21 15:15:53 [JOB] attempting to acquire lock for job::12 on host::dev.ted.com pid::18181
2011-12-21 15:15:53 [JOB] job::12 Caught DJRetryException 'Exception message.' on attempt 3/3. Giving up.
2011-12-21 15:15:53 [JOB] failure in job::12
```
