### PR TITLE
Support PHP versions < 5.3

### DIFF
--- a/DJJob.php
+++ b/DJJob.php
@@ -190,7 +190,10 @@ class DJWorker extends DJBase {
 
                 if (!$job) {
                     $this->log("[JOB] Failed to get a job, queue::{$this->queue} may be empty", self::DEBUG);
-                    sleep($this->sleep);
+                    // require for signal support in versions < 5.3
+                    declare(ticks=1) {
+                        sleep($this->sleep);
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
PHP 5.3 introduced pcntl_signal_dispatch().  To support signal handling in versions less than 5.3, we need to use ticks.  I've done so by wrapping the sleep call in a ticks block.  This ensures that the signal handlers only get called after the sleep and not while a job is executing.
