### PR TITLE
Allow error function to be defined on job that will be executed on final job failure

### DIFF
--- a/DJJob.php
+++ b/DJJob.php
@@ -307,8 +307,8 @@ class DJJob extends DJBase {
         $this->log("[JOB] failure in job::{$this->job_id}", self::ERROR);
         $this->releaseLock();
         
-        if ($handler && ($this->getAttempts() == $this->max_attempts) && method_exists($handler, 'errorOnPerform')) {
-          $handler->errorOnPerform($error);
+        if ($handler && ($this->getAttempts() == $this->max_attempts) && method_exists($handler, '_onDjjobRetryError')) {
+          $handler->_onDjjobRetryError($error);
         }
     }
 


### PR DESCRIPTION
- define function errorOnPerform($error) on the job object that takes the error message as an argument.
- allows the job object to handle the situation where a job has failed for the final time.
