### PR TITLE
DJJob struggles when there is unicode. Lots of "badHandlers"

### DIFF
--- a/DJJob.php
+++ b/DJJob.php
@@ -363,11 +363,11 @@ class DJJob extends DJBase {
         $this->releaseLock();
     }
         
-    protected function serialize($object) {
+    protected static function serialize($object) {
       return base64_encode(serialize($object));
     }
 
-    protected function unserialize($data) {
+    protected static function unserialize($data) {
       return unserialize(base64_decode($data));
     }
 
@@ -377,7 +377,7 @@ class DJJob extends DJBase {
             "SELECT handler FROM jobs WHERE id = ?",
             array($this->job_id)
         );
-        foreach ($rs as $r) return $this->unserialize($r["handler"]);
+        foreach ($rs as $r) return self::unserialize($r["handler"]);
         return false;
     }
 
@@ -393,7 +393,7 @@ class DJJob extends DJBase {
     public static function enqueue($handler, $queue = "default", $run_at = null) {
         $affected = self::runUpdate(
             "INSERT INTO jobs (handler, queue, run_at, created_at) VALUES(?, ?, ?, NOW())",
-            array($this->serialize($handler), (string) $queue, $run_at)
+            array(self::serialize($handler), (string) $queue, $run_at)
         );
 
         if ($affected < 1) {
@@ -410,7 +410,7 @@ class DJJob extends DJBase {
 
         $parameters = array();
         foreach ($handlers as $handler) {
-            $parameters []= $this->serialize($handler);
+            $parameters []= self::serialize($handler);
             $parameters []= (string) $queue;
             $parameters []= $run_at;
         }


### PR DESCRIPTION
There's an issue which I've been unable to fix otherwise wherein djjob can't deserialize unicode or utf-8 characters (I'm not sure which.)

This solves it by encoding the serialized data as base64.

It's worth noting that this will break existing job queues as the encoding has changed.
