### PR TITLE
Added an option to fail jobs if any output is detected.  This was primar...

### DIFF
--- a/DJJob.php
+++ b/DJJob.php
@@ -333,17 +333,17 @@ class DJJob extends DJBase {
         # run the handler
         try {
 
-            if($this->fail_on_output){
+            if ($this->fail_on_output) {
                 ob_start();                
             }
 
             $handler->perform();
 
-            if($this->fail_on_output){
+            if ($this->fail_on_output) {
                 $output = ob_get_contents();
                 ob_end_clean();
 
-                if(!empty($output)){
+                if (!empty($output)) {
                     throw new Exception("Job produced unexpected output: $output");
                 }
             }


### PR DESCRIPTION
Added an option to fail jobs if any output is detected. This was primarily intended for the cases where a PHP warning is printed, but no exception is thrown (like for undefined variables).  By default, jobs still succeed those cases.  After setting 'fail_on_output' to true, jobs with any output will fail with the output included in the 'error' database column.
