### PR TITLE
document using BLOB data type for handler

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -29,6 +29,8 @@ bc. CREATE TABLE `jobs` (
 `created_at` DATETIME NOT NULL
 ) ENGINE = INNODB;
 
+You may need to use BLOB as the column type for @handler@ if storing a "lot of data":https://php.net/manual/en/function.serialize.php#refsect1-function.serialize-returnvalues and having issues like @unserialize(): Error at offset 2010 of 2425 bytes@
+
 p. Tell DJJob how to connect to your database:
 
 bc. DJJob::configure(['driver'=> 'mysql','host'=> '127.0.0.1','dbname'=> 'djjob','user'=> 'root','password'=> 'topsecret',


### PR DESCRIPTION
DDJob uses PHP's `serialize()` function to store data in the `handler` column.

From the PHP docs on `serialize()`.
> Note that this is a binary string which may include null bytes, and needs to be stored and handled as such. For example, serialize() output should generally be stored in a BLOB field in a database, rather than a CHAR or TEXT field.

https://php.net/manual/en/function.serialize.php#refsect1-function.serialize-returnvalues

A common symptom of this is errors like:

> Notice: unserialize(): Error at offset 2010 of 2425 bytes  in /var/www/magento/current/lib/DJJob/DJJob.php on line 454

I did not change the tests as they're using the `MEMORY` table type which is incompatible with `BLOB`.