### PR TITLE
Add enqueueDelayed method

### DIFF
--- a/DJJob.php
+++ b/DJJob.php
@@ -672,6 +672,19 @@ class DJJob extends DJBase {
     }
 
     /**
+     * Enqueues a job delayed to the database.
+     *
+     * @param object $handler The handler that can execute this job.
+     * @param string $queue The queue to enqueue this job to. All queues are saved in the same table.
+     * @param int    $delay The amount of seconds to delay this job.
+     */
+    public static function enqueueDelayed($handler, $queue = "default", $delay = 0) {
+        $runAt = self::runQuery("SELECT DATE_ADD(NOW(), INTERVAL ? SECOND) as `delayed`", array($delay));
+
+        return self::enqueue($handler, $queue, $runAt[0]['delayed']);
+    }
+
+    /**
      * Bulk enqueues a lot of jobs to the database.
      *
      * @param object[] $handlers An array of handlers to enqueue.


### PR DESCRIPTION
Adds a method to delay a job by a number of seconds. When using run_at we were facing that our MySQL server was running a different timezone than our PHP server. This PR introduces a method that makes sure the PHP doesn't have to know about the timezone of MySQL.

Alternative to #48.

Pros:
* Less duplicated code.

Cons:
* One more SQL query.